### PR TITLE
Fix path-like links for cygwin-like paths on Windows

### DIFF
--- a/dephell_links/__init__.py
+++ b/dephell_links/__init__.py
@@ -4,6 +4,7 @@ from ._path import DirLink, FileLink
 from ._unknown import UnknownLink
 from ._url import URLLink
 from ._vcs import VCSLink
+from ._constants import IS_WINDOWS
 
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     'UnknownLink',
     'URLLink',
     'VCSLink',
+    'IS_WINDOWS',
 ]

--- a/dephell_links/_constants.py
+++ b/dephell_links/_constants.py
@@ -1,0 +1,6 @@
+# built-in
+import os
+import platform
+
+
+IS_WINDOWS = (os.name == 'nt') or (platform.system() == 'Windows')

--- a/dephell_links/_path.py
+++ b/dephell_links/_path.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 # app
 from ._cached_property import cached_property
+from ._constants import IS_WINDOWS
 
 
 class _PathLink:
@@ -17,7 +18,10 @@ class _PathLink:
     def parse(cls, link) -> Optional['_PathLink']:
         if '@' in link:
             return None
-        if link.startswith('file://'):
+        if IS_WINDOWS and link.startswith('file:///'):
+            # cygwin-like absolute paths (file:///c:/foo/bar)
+            link = link[len('file:///'):]
+        elif link.startswith('file://'):
             link = link[len('file://'):]
         if '://' in link:
             return None

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,16 +1,43 @@
+# built-in
+from pathlib import Path
+
 # project
 import pytest
-from dephell_links import DirLink, FileLink, URLLink, VCSLink, parse_link
+from dephell_links import DirLink, FileLink, URLLink, VCSLink, parse_link, IS_WINDOWS
 
 
-@pytest.mark.parametrize('link_type, url', [
-    (VCSLink, 'https://github.com/r1chardj0n3s/parse.git'),
-    (URLLink, 'https://github.com/divio/django-cms/archive/release/3.4.x.zip'),
-    (FileLink, './tests/test_parsing.py'),
-    (FileLink, './this_file_does_not_exists.py'),
-    (DirLink, '.'),
+skipif_not_windows = pytest.mark.skipif(not IS_WINDOWS, reason='not Windows')
+
+
+@pytest.mark.parametrize('link_type, url, expected', [
+    (VCSLink, 'https://github.com/r1chardj0n3s/parse.git', None),
+    (URLLink, 'https://github.com/divio/django-cms/archive/release/3.4.x.zip', None),
+    (FileLink, './tests/test_parsing.py', None),
+    (FileLink, 'file://./tests/test_parsing.py', './tests/test_parsing.py'),
+    (FileLink, 'file://{}'.format(Path('./tests/test_parsing.py').absolute()),
+     str(Path('./tests/test_parsing.py').absolute())),
+    (FileLink, 'file://{}'.format(Path('./tests/test_parsing.py').absolute().as_posix()),
+     Path('./tests/test_parsing.py').absolute().as_posix()),
+    (FileLink, './this_file_does_not_exists.py', None),
+    (DirLink, '.', None),
+    (DirLink, 'file://.', '.'),
+    (DirLink, 'file://{}'.format(Path('.').absolute()), str(Path('.').absolute())),
+    (DirLink, 'file://{}'.format(Path('.').absolute().as_posix()), Path('.').absolute().as_posix()),
+
+    # Windows only
+    pytest.param(FileLink, 'file:///{}'.format(Path('./tests/test_parsing.py').absolute().as_posix()),
+                 Path('./tests/test_parsing.py').absolute().as_posix(), marks=skipif_not_windows),
+    pytest.param(FileLink, 'file:///{}'.format(Path('./tests/test_parsing.py').absolute()),
+                 str(Path('./tests/test_parsing.py').absolute()), marks=skipif_not_windows),
+    pytest.param(DirLink, 'file:///{}'.format(Path('.').absolute().as_posix()),
+                 Path('.').absolute().as_posix(), marks=skipif_not_windows),
+    pytest.param(DirLink, 'file:///{}'.format(Path('.').absolute()),
+                 str(Path('.').absolute()), marks=skipif_not_windows),
 ])
-def test_parsing(link_type, url):
+def test_parsing(link_type, url, expected):
     link = parse_link(url)
     assert isinstance(link, link_type)
-    assert link.short == url
+
+    if not expected:
+        expected = url
+    assert link.short == expected


### PR DESCRIPTION
- Fix paths look like this: `file:///c:/foo/bar`

Related to: https://github.com/dephell/dephell/issues/343